### PR TITLE
🚀 feat: allow or disallow node configuration and dependency installation

### DIFF
--- a/.github/workflows/sonarcloud-nodejs-yarn-scan-workflow.yml
+++ b/.github/workflows/sonarcloud-nodejs-yarn-scan-workflow.yml
@@ -12,6 +12,11 @@ on:
         type: string
         description: "SonarCloud organization (required if sonar-project.properties does not exist)"
         default: "n1co"
+      requires-node-setup-and-install-dependencies:
+        description: "requires Node.js setup and dependencies installation"
+        type: boolean
+        required: false
+        default: true
       env-name:
         required: true
         type: string
@@ -35,14 +40,17 @@ jobs:
 
     steps:
       - name: Checkout code
+        if: ${{ inputs.requires-node-setup-and-install-dependencies }}
         uses: actions/checkout@v4
 
       - name: Setup Node.js
+        if: ${{ inputs.requires-node-setup-and-install-dependencies }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Install dependencies
+        if: ${{ inputs.requires-node-setup-and-install-dependencies }}
         working-directory: ${{ inputs.build-path }}
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/trivy-nodejs-yarn-scan-workflow.yml
+++ b/.github/workflows/trivy-nodejs-yarn-scan-workflow.yml
@@ -13,6 +13,11 @@ on:
         type: string
         required: true
         default: "."
+      requires-node-setup-and-install-dependencies:
+        description: "requires Node.js setup and dependencies installation"
+        type: boolean
+        required: false
+        default: true
       requires-gh-npm-config:
         description: "requires GitHub-NPM configuration"
         type: boolean
@@ -48,9 +53,11 @@ jobs:
 
     steps:
       - name: Checkout code
+        if: ${{ inputs.requires-node-setup-and-install-dependencies }}
         uses: actions/checkout@v4
 
       - name: Set up Node.js
+        if: ${{ inputs.requires-node-setup-and-install-dependencies }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
@@ -70,6 +77,7 @@ jobs:
           echo //${{ inputs.registry-domain }}/:_authToken=${{ env.GH_PAT }} >> .npmrc
 
       - name: Install dependencies
+        if: ${{ inputs.requires-node-setup-and-install-dependencies }}
         run: yarn install --frozen-lockfile
 
       - name: Initialize result files


### PR DESCRIPTION
This pull request introduces changes to two GitHub workflow files to add a new input parameter that controls whether Node.js setup and dependency installation steps should be executed. The most important changes are as follows:

Enhancements to workflow files:

* [`.github/workflows/sonarcloud-nodejs-yarn-scan-workflow.yml`](diffhunk://#diff-b682c74bb6c02861a8e8831d680b13f0907074ef26588f11946cc5740bdbfe45R15-R19): Added a new boolean input parameter `requires-node-setup-and-install-dependencies` with a default value of `true`. This parameter is used to conditionally execute the Node.js setup and dependency installation steps. [[1]](diffhunk://#diff-b682c74bb6c02861a8e8831d680b13f0907074ef26588f11946cc5740bdbfe45R15-R19) [[2]](diffhunk://#diff-b682c74bb6c02861a8e8831d680b13f0907074ef26588f11946cc5740bdbfe45R43-R53)
* [`.github/workflows/trivy-nodejs-yarn-scan-workflow.yml`](diffhunk://#diff-b091d1903caaa2af15a589c51e93071386d6e89fa4bfeeca4d27ddaec40e5a81R16-R20): Added a new boolean input parameter `requires-node-setup-and-install-dependencies` with a default value of `true`. This parameter is used to conditionally execute the Node.js setup and dependency installation steps. [[1]](diffhunk://#diff-b091d1903caaa2af15a589c51e93071386d6e89fa4bfeeca4d27ddaec40e5a81R16-R20) [[2]](diffhunk://#diff-b091d1903caaa2af15a589c51e93071386d6e89fa4bfeeca4d27ddaec40e5a81R56-R60) [[3]](diffhunk://#diff-b091d1903caaa2af15a589c51e93071386d6e89fa4bfeeca4d27ddaec40e5a81R80)